### PR TITLE
Vscode config

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -33,11 +33,6 @@ lenstr () {
     echo -n $1 | wc -c
 }
 
-# open a file in vs code from the command line
-vscode () {
-    open -a Visual\ Studio\ Code $1
-}
-
 # get git branch info for displaying on the terminal prompt
 parse_git_branch () {
  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'

--- a/.zshrc
+++ b/.zshrc
@@ -49,11 +49,6 @@ function lenstr {
     echo -n $1 | wc -c
 }
 
-# open a file in vs code from the command line
-function vscode {
-    open -a Visual\ Studio\ Code $1
-}
-
 # open a man page in preview dot app
 function manpage {
     man -t $1 | open -fa Preview

--- a/code-extensions.sh
+++ b/code-extensions.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+# need to follow the directions at 
+# https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line first
+
+
+declare -a extensions=(
+    'ms-azuretools.vscode-docker' \
+    'hashicorp.terraform' \
+    'ms-python.vscode-pylance' \
+    'ms-python.python' \
+    'mechatroner.rainbow-csv' \
+    'formulahendry.terminal'
+    )
+
+for val in ${extensions[@]}; do
+    code --install-extension $val
+done


### PR DESCRIPTION
removed the "vscode" alias since vscode does this with the code command once it's installed.